### PR TITLE
fix: prefix locator is set to 'default' if prefix is None on 'find' method but there is no 'default' on strategies

### DIFF
--- a/AppiumFlutterLibrary/finder/elementfinder.py
+++ b/AppiumFlutterLibrary/finder/elementfinder.py
@@ -10,6 +10,7 @@ class ElementFinder():
             'semantics': self._find_by_semantics_label,
             'tooltip': self._find_by_tooltip_message,
             'type': self._find_by_type,
+            'default': self._find_by_key,
         }
 
     def find(self, application, locator):


### PR DESCRIPTION
fix: prefix locator is set to 'default' if prefix is None on 'find' method but there is no 'default' on strategies

Example :
`Click Element    keyName`

Error in logs was : 

> ValueError: Element locator with prefix 'default' is not supported