### PR TITLE
feat: new get render tree keyword

### DIFF
--- a/AppiumFlutterLibrary/keywords/_applicationmanagement.py
+++ b/AppiumFlutterLibrary/keywords/_applicationmanagement.py
@@ -115,6 +115,16 @@ class _ApplicationManagementKeyWords(KeywordGroup):
         See `Set Appium Timeout` for an explanation."""
         return robot.utils.secs_to_timestr(self._timeout_in_secs)
 
+    def get_render_tree(self):
+        """
+        Gets the string representation of the render tree.
+
+        Example:
+        | ${tree} = | Get Render Tree |
+        | Log | ${tree} |
+        """
+        return self._current_application().execute_script('flutter: getRenderTree')
+
     # Private
 
     def _current_application(self):


### PR DESCRIPTION
Could be usefull to have render tree if we can't inspect the flutter app

https://api.flutter.dev/flutter/flutter_driver/GetRenderTree-class.html 
Prettry the same than Log Source https://serhatbolsu.github.io/robotframework-appiumlibrary/AppiumLibrary.html#Log%20Source