### PR TITLE
feat: flutter scroll keyword (fix #13)

### DIFF
--- a/AppiumFlutterLibrary/keywords/_touch.py
+++ b/AppiumFlutterLibrary/keywords/_touch.py
@@ -27,3 +27,25 @@ class _TouchKeywords(KeywordGroup):
         driver = self._current_application()
         element = self._element_find(locator, True, True)
         driver.execute_script("mobile: scroll", {"direction": 'up', 'elementid': element.id})
+
+    def flutter_scroll(self, locator, dx, dy, durationmilliseconds=200, frequency=60):
+        """ Tell the driver to perform a scrolling action.
+        A scrolling action begins with a "pointer down" event, which commonly maps to finger press on the touch screen
+        or mouse button press. A series of "pointer move" events follow.
+        The action is completed by a "pointer up" event.
+
+        dx and dy specify the total offset for the entire scrolling action.
+
+        durationmilliseconds specifies the length of the action in milliseconds.
+
+        The move events are generated at a given frequency in Hz (or events per second). It defaults to 60Hz.
+        """
+        application = self._current_application()
+        element = self._element_finder.find(application, locator)
+        try:
+            application.execute_script('flutter:scroll',
+                                       element.id,
+                                       {'durationMilliseconds': int(durationmilliseconds), 'dx': int(dx), 'dy': int(dy),
+                                        'frequency': int(frequency)})
+        except Exception:
+            raise AssertionError("Unable to perform scroll")


### PR DESCRIPTION
Hi,

I managed to make a working left/right/up/down scroll/swipe keyword.
It's usefull to do a left/right swipe for slidebar for example.
Feel free to modify the name of the keyword or clean the code, because i'm pretty bad with python.
I tested the keyword on my flutter app successfully.

Arguments are :
- 'locator'
- 'dx' and 'dy' : specify the total offset for the entire scrolling action.
- 'durationmilliseconds' : specifies the length of the action in milliseconds.
- 'frequency' : The move events are generated at a given frequency in Hz (or events per second). It defaults to 60Hz.

Example : 
```
Flutter Scroll    sliderKey    dx=50    dy=1    durationmilliseconds=200
... Some actions
Flutter Scroll    sliderKey    dx=-50    dy=1    durationmilliseconds=1000
```

BR