### PR TITLE
fix: readd runonfailure feature

### DIFF
--- a/AppiumFlutterLibrary/__init__.py
+++ b/AppiumFlutterLibrary/__init__.py
@@ -49,7 +49,7 @@ class AppiumFlutterLibrary(
 	ROBOT_LIBRARY_SCOPE = 'GLOBAL'
 	ROBOT_LIBRARY_VERSION = VERSION
 
-	def __init__(self, timeout=5, run_on_failure='Capture Page Screenshot'):
+	def __init__(self, timeout=5, run_on_failure='AppiumFlutterLibrary.Capture Page Screenshot'):
 		"""AppiumFlutterLibrary can be imported with optional arguments.
         ``timeout`` is the default timeout used to wait for all waiting actions.
         It can be later set with `Set Appium Timeout`.

--- a/AppiumFlutterLibrary/keywords/_runonfailure.py
+++ b/AppiumFlutterLibrary/keywords/_runonfailure.py
@@ -1,20 +1,47 @@
 # -*- coding: utf-8 -*-
 
+from robot.libraries import BuiltIn
 from AppiumFlutterLibrary.keywords.keywordgroup import KeywordGroup
 
+BUILTIN = BuiltIn.BuiltIn()
 
 class _RunOnFailureKeyWords(KeywordGroup):
     def __init__(self):
         self._run_on_failure_keyword = None
-        self._running_on_failure_routine = None
+        self._running_on_failure_routine = False
     
+    # Public
+
     def register_keyword_to_run_on_failure(self, keyword):
         old_keyword = self._run_on_failure_keyword
         old_keyword_text = old_keyword if old_keyword is not None else "Nothing"
 
-        new_keyword = keyword if keyword.strip().lower() != "nothing" else "Nothing"
+        new_keyword = keyword if keyword.strip().lower() != "nothing" else None
         new_keyword_text = new_keyword if new_keyword is not None else "Nothing"
 
         self._run_on_failure_keyword = new_keyword
+        self._info('%s will be run on failure.' % new_keyword_text)
 
-        return old_keyword
+        return old_keyword_text
+
+    # Private
+
+    def _run_on_failure(self):
+        if self._run_on_failure_keyword is None:
+            return
+        if self._running_on_failure_routine:
+            return
+        self._running_on_failure_routine = True
+        try:
+            BUILTIN.run_keyword(self._run_on_failure_keyword)
+        except Exception as err:
+            self._run_on_failure_error(err)
+        finally:
+            self._running_on_failure_routine = False
+
+    def _run_on_failure_error(self, err):
+        err = "Keyword '%s' could not be run on failure: %s" % (self._run_on_failure_keyword, err)
+        if hasattr(self, '_warn'):
+            self._warn(err)
+            return
+        raise Exception(err)


### PR DESCRIPTION
The 'run on failure' feature was modified/removed and the 'run_on_failure' import arg wasn't working anymore

(the removed [_run_on_failure](https://github.com/Rodaxfck/robotframework-appiumflutterlibrary/blob/d104f8ee4d0296744aed4089fb4021a8548a7a16/AppiumFlutterLibrary/keywords/_runonfailure.py#L29) was called on the function [_run_on_failure_decorator](https://github.com/Rodaxfck/robotframework-appiumflutterlibrary/blob/d104f8ee4d0296744aed4089fb4021a8548a7a16/AppiumFlutterLibrary/keywords/keywordgroup.py#L13)

Fix for #15 